### PR TITLE
improve app start up performance

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -21,13 +21,11 @@ app_server <- function(input, output, session) {
   # load all other modules once the home module has finished loading
   init_timeout <- TRUE
   init <- shiny::observe({
-    cat("triggered init\n")
     shiny::req(params$dataset)
     if (init_timeout) {
       shiny::invalidateLater(50)
       shiny::req((init_timeout <<- FALSE))
     }
-    cat("loading modules\n")
 
     shiny::isolate({
       provider_data <- shiny::reactive({


### PR DESCRIPTION
prevents the modules from loading until the home module has finished loading by observing `params$dataset` (i.e. the providers drop down is ready), and then adding in a slight delay to make sure the map on the home module has loaded by invalidating later.