### PR TITLE
removes run model for certain users

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -74,7 +74,13 @@ app_server <- function(input, output, session) {
       diagnoses_lkup()
     )
 
-    mod_run_model_server("run_model", params)
+    # enable the run_model page for certain users/running locally
+    is_local <- Sys.getenv("SHINY_PORT") == ""
+    is_power_user <- any(c("nhp_devs", "nhp_power_users") %in% session$groups)
+    if (is_local || is_power_user) {
+      shinyjs::show("run-model-container")
+      mod_run_model_server("run_model", params)
+    }
 
     # hacky way of achieving switch from the home tab to the app itself
     # maybe add some timeout to this?

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -138,11 +138,16 @@ app_ui <- function(request) {
           tabName = "tab_theatres"
         ),
         #
-        shiny::tags$hr(),
-        bs4Dash::sidebarHeader("Run Model"),
-        bs4Dash::menuItem(
-          "Run Model",
-          tabName = "tab_run_model"
+        shinyjs::hidden(
+          shiny::tags$div(
+            id = "run-model-container",
+            shiny::tags$hr(),
+            bs4Dash::sidebarHeader("Run Model"),
+            bs4Dash::menuItem(
+              "Run Model",
+              tabName = "tab_run_model"
+            )
+          )
         )
       )
     )


### PR DESCRIPTION
by default, hide the run_model page. if the user is a member of the nhp_devs or nhp_power_users (or, if it's running on localhost), then the run model page is displayed

fixes 147
