### PR TITLE
retitle reasons box to supporting rationale

### DIFF
--- a/R/mod_reasons_ui.R
+++ b/R/mod_reasons_ui.R
@@ -10,7 +10,7 @@
 mod_reasons_ui <- function(id) {
   ns <- shiny::NS(id)
   bs4Dash::box(
-    title = "Reasons",
+    title = "Supporting Rationale",
     width = 12,
     shiny::textAreaInput(
       ns("value"),


### PR DESCRIPTION
fixes #158

keeps the module named "reasons", but updates the title on the boxes