### PR TITLE
improves app startup by disabling multisession when running locally

### DIFF
--- a/R/ZZZ.R
+++ b/R/ZZZ.R
@@ -67,3 +67,8 @@ params_filename <- function(user, dataset, scenario) {
     paste0(scenario, ".json")
   )
 }
+
+# check to see whether the app is running locally or in production
+is_local <- function() {
+  Sys.getenv("SHINY_PORT") == "" || !getOption("golem.app.prod", TRUE)
+}

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -76,9 +76,9 @@ app_server <- function(input, output, session) {
     )
 
     # enable the run_model page for certain users/running locally
-    is_local <- Sys.getenv("SHINY_PORT") == ""
+
     is_power_user <- any(c("nhp_devs", "nhp_power_users") %in% session$groups)
-    if (is_local || is_power_user) {
+    if (is_local() || is_power_user) {
       shinyjs::show("run-model-container")
       mod_run_model_server("run_model", params)
     }

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -20,7 +20,9 @@ run_app <- function(onStart = NULL, # nolint
   }
 
   # required for async promise calls
-  future::plan(future::multisession)
+  if (!is_local()) {
+    future::plan(future::multicore)
+  }
 
   golem::with_golem_options(
     app = shiny::shinyApp(


### PR DESCRIPTION
there is possibly more work we could do to profile the app, but for now this cuts app startup locally from >10s to ~1s.

I don't think this issue exists on Linux which handles multisession better anyway, but I've switched to multicore which should offer better performance when running on a unix based system