### PR TITLE
197 Set maximum and default year to 2041

### DIFF
--- a/R/mod_home_server.R
+++ b/R/mod_home_server.R
@@ -104,7 +104,7 @@ mod_home_server <- function(id, providers) {
     shiny::observe({
       x <- as.numeric(stringr::str_sub(input$start_year, 1, 4))
 
-      fy_yyyy <- seq(x + 1, 2043)  # 2043 fixed as latest possible end year
+      fy_yyyy <- seq(x + 1, 2041)  # 2043 fixed as latest possible end year
       fy_yy <- stringr::str_sub(fy_yyyy + 1, 3, 4)
       fy_choices <- paste(fy_yyyy, fy_yy, sep = "/")
       fy_choices_num <- setNames(fy_yyyy, fy_choices)

--- a/R/mod_home_ui.R
+++ b/R/mod_home_ui.R
@@ -30,8 +30,17 @@ mod_home_ui <- function(id) {
       width = 12,
       shiny::selectInput(ns("cohort"), "Cohort", c("Current", "All Other Providers")),
       shiny::selectInput(ns("dataset"), "Provider", choices = NULL, selectize = TRUE),
-      shiny::selectInput(ns("start_year"), "Baseline Financial Year", choices = c("2019/20" = 201920, "2018/19" = 201819)),
-      shiny::selectInput(ns("end_year"), "Model Financial Year", choices = setNames(as.character(0:23), paste(2020:2043, 21:44, sep = "/")))
+      shiny::selectInput(
+        ns("start_year"),
+        "Baseline Financial Year",
+        choices = c("2019/20" = 201920, "2018/19" = 201819)
+      ),
+      shiny::selectInput(
+        ns("end_year"),
+        "Model Financial Year",
+        choices = setNames(as.character(0:21), paste(2020:2041, 21:42, sep = "/")),
+        selected = "21"
+      )
     ),
     bs4Dash::box(
       title = "Scenario",


### PR DESCRIPTION
Closes #197.

Note that I've used 2043 (not 2041) as the max, given Tom's comment in a Teams chat that I've noted in issue #197.

- The lowest model year in the home-page dropdown remains responsive (baseline year + 1).
- The highest year maxes out at 2043, regardless of baseline year.
- The default year selected is also 2043.

