### PR TITLE
ensures container name is less than 64 characters long

### DIFF
--- a/R/mod_run_model_fix_params.R
+++ b/R/mod_run_model_fix_params.R
@@ -43,7 +43,7 @@ mod_run_model_fix_params <- function(p) {
   hash <- digest::digest(p, "crc32", serialize = TRUE)
 
   p$id <- glue::glue("{p$dataset}-{scenario_sanitized}") |>
-    stringr::str_sub(1, 63 - stringr::str_length(hash)) |>
+    stringr::str_sub(1, 62 - stringr::str_length(hash)) |>
     stringr::str_to_lower() |>
     paste0("-", hash)
 


### PR DESCRIPTION
ACI instance names must be 63 characters or less. As we append "-" and the hash, we need to ensure the prefix is at most 54 characters long (CRC32 hashes are 8 characters long)