### PR TITLE
forces some time profile mappings to none

### DIFF
--- a/R/mod_run_model_fix_params.R
+++ b/R/mod_run_model_fix_params.R
@@ -6,11 +6,20 @@ mod_run_model_fix_params <- function(p) {
     op = tpm[["activity_avoidance"]][["op"]] %||% list(),
     aae = tpm[["activity_avoidance"]][["aae"]] %||% list()
   )
-
   p[["time_profile_mappings"]][["efficiencies"]] <- list(
     ip = tpm[["efficiencies"]][["ip"]] %||% list(),
     op = tpm[["efficiencies"]][["op"]] %||% list()
   )
+
+  # for a while, the wrong time profile was set for some items. force these to none
+  p[["time_profile_mappings"]][
+    c(
+      "covid_adjustment",
+      "baseline_adjustment",
+      "bed_occupancy",
+      "non-demographic_adjustment"
+    )
+  ] <- "none"
 
   # some of the items in our params will be lists of length 0.
   # jsonlite will serialize these as empty arrays


### PR DESCRIPTION
the time profile mapping for non-demographic was set incorrectly in the default params file initially. If anyone created the params with these bad defaults then the model will fail to run. This forces any values to be set correctly