### PR TITLE
fix diuretics typo

### DIFF
--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -70,7 +70,7 @@ default:
         medicines_related_admissions_explicit: "Medicines Related Admissions (Explicit)"
         medicines_related_admissions_implicit_anti-diabetics: "Medicines Related Admissions (Implicit - Anti-Diabetics)"
         medicines_related_admissions_implicit_benzodiasepines: "Medicines Related Admissions (Implicit - Benzodiazepines)"
-        medicines_related_admissions_implicit_diurectics: "Medicines Related Admissions (Implicit - Diurectics)"
+        medicines_related_admissions_implicit_diurectics: "Medicines Related Admissions (Implicit - Diuretics)"
         medicines_related_admissions_implicit_nsaids: "Medicines Related Admissions (Implicit - NSAIDs)"
         obesity_related_admissions: "Obesity Related Admissions"
         raid_ae: "Mental Health Admissions via Emergency Department"

--- a/manifest.json
+++ b/manifest.json
@@ -6357,7 +6357,7 @@
       "checksum": "35f183672422864199cea4257a4fb332"
     },
     "inst/golem-config.yml": {
-      "checksum": "5412b2f45e54642369cbb6f9ff6bcd92"
+      "checksum": "6e42e00024e213848aa90b3fe1288fba"
     },
     "inst/WORDLIST": {
       "checksum": "3855faecd79c7c5699b99e1045fc3948"


### PR DESCRIPTION
partially resolves #215 

the strategy itself remains incorrectly spelt, which will probably propagate through to the model and outputs.

@matt-dray - I think this would only be on the waterfall diagram. But at present we only do some simple changes to title case the strategies there. We should probably have a lookup in the future
