### PR TITLE
Set 'model version' to latest when selecting 'create new'

### DIFF
--- a/app.R
+++ b/app.R
@@ -1,4 +1,4 @@
-app_version_choices <- c("v1.1", "v1.0", "dev")
+app_version_choices <- jsonlite::fromJSON(Sys.getenv("APP_VERSION_CHOICES", "[\"dev\"]"))
 
 "%||%" <- function(x, y) { # nolint
   if (is.null(x)) {


### PR DESCRIPTION
Closes #285.

* Creates `app_version_choices` vector.
* `selectInput()` reads from `app_version_choices`.
* New observer resets the `selected` version to the latest (i.e. index 1 in `app_version_choices`) when the `scenario_type` input changes to 'Create new from scratch'.