### PR TITLE
Correct default NDG to Variant 2

### DIFF
--- a/R/mod_non_demographic_adjustment_utils.R
+++ b/R/mod_non_demographic_adjustment_utils.R
@@ -60,7 +60,7 @@ nda_groups <- list(
 
 detect_non_demographic_variant <- function(p_ndg, ndg_variants) {
 
-  detected_ndg_variant <- "variant_1"  # default
+  detected_ndg_variant <- "variant_2"  # default
 
   current_ndg_values <- unlist(p_ndg)  # NULL if new scenario
 


### PR DESCRIPTION
Closes #299.

Change tge default from "variant_1" to "variant_2" in the variant detection function `detect_non_demographic_variant()`.