### PR TITLE
updates to use new run_model_v2 api

### DIFF
--- a/R/mod_run_model_fix_params.R
+++ b/R/mod_run_model_fix_params.R
@@ -52,23 +52,8 @@ mod_run_model_fix_params <- function(p) {
   # need to convert financial year to calendar year
   p$start_year <- as.integer(stringr::str_sub(p$start_year, 1, 4))
 
-  # generate an id based on the dataset, scenario, and a hash of the params
-  # make sure to add the user after creating the hash
-  # the id must be at most 63 characters long, and must match the regex:
-  #   '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
-  scenario_sanitized <- p$scenario |>
-    stringr::str_to_lower() |>
-    stringr::str_replace_all("[^a-z0-9]+", "-")
-  hash <- digest::digest(p, "crc32", serialize = TRUE)
-
-  p$id <- glue::glue("{p$dataset}-{scenario_sanitized}") |>
-    stringr::str_sub(1, 62 - stringr::str_length(hash)) |>
-    stringr::str_to_lower() |>
-    paste0("-", hash)
-
   # reorder the params
   p_order <- c(
-    "id",
     "user",
     "dataset",
     "scenario",
@@ -77,7 +62,6 @@ mod_run_model_fix_params <- function(p) {
     "start_year",
     "end_year",
     "app_version",
-    "create_datetime",
     "interval_type",
     "demographic_factors",
     "health_status_adjustment",

--- a/R/mod_run_model_server.R
+++ b/R/mod_run_model_server.R
@@ -53,28 +53,9 @@ mod_run_model_server <- function(id, params) {
       p <- shiny::req(fixed_params())
       t <- Sys.time()
       attr(t, "tzone") <- "UTC"
-      p$create_datetime <- format(t, "%Y%m%d_%H%M%S")
-
-      # generate the results url
-      version <- p$app_version
-      f <- encrypt_filename( # nolint
-        file.path(
-          "prod",
-          version,
-          p$dataset,
-          glue::glue("{p$scenario}-{p$create_datetime}.json.gz"),
-          fsep = "/"
-        )
-      )
-
-      # update version for the url
-      version <- stringr::str_replace(version, "^v(\\d)+\\.(\\d+).*", "v\\1-\\2")
-      results_url(
-        glue::glue(Sys.getenv("NHP_OUTPUTS_URI"), "?{utils::URLencode(f, TRUE)}")
-      )
 
       # submit the model run
-      mod_run_model_submit(p, status)
+      mod_run_model_submit(p, status, results_url)
 
       # do not return the promise
       invisible(NULL)


### PR DESCRIPTION
the new api generates the id and create_datetime values in the params file, so these are removed. these values are instead returned by the api
