### PR TITLE
temporary fix to provider successors

### DIFF
--- a/targets/R/get_provider_successors.R
+++ b/targets/R/get_provider_successors.R
@@ -14,7 +14,8 @@ get_provider_successors <- function(ods_successors, list_providers) {
       tibble::tribble(
         ~old_code, ~new_code,
         "RBA", "RH5", # missing row for Taunton and Somerset NHS FT -> Somerset NHS FT
-        "RA3", "RA7" # missing row for Weston Area Health NHS Trust -> Univesity Hospitals Bristol and Weston NHS FT
+        "RA3", "RA7", # missing row for Weston Area Health NHS Trust -> Univesity Hospitals Bristol and Weston NHS FT
+        "RBZ", "RH8" # missing row for Northern Devon Healthcare NHS Trust -> Royal Devon University Healthcare NHS FT
       ),
       by = "old_code"
     )


### PR DESCRIPTION
there is a missing row of data in the succesors excel download. temporary fix to add this back in

long term might need to switch to the xml download or api calls
