### PR TITLE
Show absolute mitigator values as text 

### DIFF
--- a/R/mod_mitigators_server.R
+++ b/R/mod_mitigators_server.R
@@ -183,16 +183,7 @@ mod_mitigators_server <- function(id, # nolint: object_usage_linter.
       floor(r * m) / m
     })
 
-    shiny::observe({
-      shiny::req(input$strategy)
-      include <- !is.null(params[[mitigators_type]][[activity_type]][[input$strategy]])
-
-      shiny::updateCheckboxInput(session, "include", value = include)
-      update_slider("% change")
-    }) |>
-      shiny::bindEvent(input$strategy)
-
-    update_slider <- function(type) {
+    shiny::observe({  # update slider
       strategy <- shiny::req(input$strategy)
       max_value <- provider_max_value()
       scale <- 100
@@ -209,7 +200,8 @@ mod_mitigators_server <- function(id, # nolint: object_usage_linter.
       update_time_profile(
         time_profile_mappings$mappings[[strategy]] %||% "linear"
       )
-    }
+    }) |>
+      shiny::bindEvent(input$strategy)
 
     shiny::observe({
       values <- input$slider

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -28,13 +28,6 @@ mod_mitigators_ui <- function(id, title) {
               ns("include"),
               "Include?"
             ),
-            # TODO: remove
-            # shiny::radioButtons(
-            #   ns("slider_type"),
-            #   "Display Type",
-            #   choices = c("Relative" = "% change", "Absolute" = "rate"),
-            #   selected = "% change"
-            # ),
             shiny::p("Note that 100% means no change and 0% means all activity
                      mitigated"),
             shiny::plotOutput(ns("nee_result"), height = 80),


### PR DESCRIPTION
Close #368.

* Remove radio buttons for toggling absolute (i.e. actual rates) and relative (0 to 100%) values in the 80% prediction-interval sliders for each mitigator.
* Default the slider to relative and show absolute text (low, high and baseline) underneath the slider.
* Added an ifelse to round percentages to 1 dp (`config$number_type` doesn't show any dp if the strategy is percentage-based).
* Grey-out the text if the mitigator hasn't been included (returns to default black if included).

Nothing fancy, basically just moved rates code into `output$slider_absolute` and displayed with an `htmlOutput()` to change colour conditionally. I've gone through and checked against prod to make sure that the rates are as expected.

Example of new look:

<img src='https://github.com/user-attachments/assets/c90e8a89-12fd-4e0c-903a-91e3928a06e2' width='400'>