### PR TITLE
Add 2023/24 to dropdown in input selection app

### DIFF
--- a/app.R
+++ b/app.R
@@ -548,12 +548,12 @@ server <- function(input, output, session) {
 
   output$baseline_202324_warning <- shiny::renderText({
     if (input$start_year == "202324") {
-      "<font color='red'>You must request and review your 2023/24 baseline data
-      before selecting 2023/24 as the baseline year. Please contact
-      <a href='mailto:mlcsu.su.datascience@nhs.net?subject=NHP request:
-      2023/24 baseline data&body=I am requesting the 2023/24 baseline data for
-      [insert scheme name].'>mlcsu.su.datascience@nhs.net</a> to request your
-      2023/24 baseline data.</font><br><br>"
+      "<font color='red'>You must request and review your 2023/24 detailed
+      baseline data before selecting 2023/24 as the baseline year. Please
+      contact <a href='mailto:mlcsu.su.datascience@nhs.net?subject=NHP request:
+      2023/24 baseline data&body=I am requesting the 2023/24 detailed baseline
+      data for [insert scheme name].'>mlcsu.su.datascience@nhs.net</a> to
+      request your 2023/24 detailed baseline data.</font><br><br>"
     }
   }) |>
     shiny::bindEvent(input$start_year)


### PR DESCRIPTION
Close #374.

* Add 2023/24 to the start-year dropdown.
* Print a warning to users about requesting their baseline data if they select this option. The linl is a pre-populated mailto.
* Retain dropdown options for 2019/20 and 2022/23 (the latter only for devs and schemes in a particular Connect group).
* Retain 2041 as the default end year.

What happens if you select 2023/24:

![image](https://github.com/user-attachments/assets/9a6bdb4e-70e0-4953-988d-5651d71a98d3)
