### PR TITLE
Correct underscore to hyphen in `value-type`

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -62,11 +62,14 @@ app_server <- function(input, output, session) {
 
     age_sex_data <- shiny::reactive({
       age_sex <- load_provider_data("age_sex")
-      age_fct <- age_sex |>
-        _[["age_group"]] |>
-        unique() |>
-        sort()
-      age_sex |> dplyr::mutate(age_group = factor(age_group, levels = age_fct))
+      age_fct <- age_sex |> _[["age_group"]] |> unique() |> sort()
+      age_sex |>
+        dplyr::mutate(
+          age_group = factor(
+            .data[["age_group"]],
+            levels = .env[["age_fct"]]
+          )
+        )
     }) |>
       shiny::bindCache(cache_version())
 

--- a/R/mod_mitigators_server.R
+++ b/R/mod_mitigators_server.R
@@ -153,7 +153,7 @@ mod_mitigators_server <- function(id, # nolint: object_usage_linter.
 
       scheme_peers <- peers |>
         dplyr::filter(.data$procode == params$dataset & .data$peer != params$dataset) |>
-        dplyr::pull(peer)
+        dplyr::pull(.data$peer)
 
       rates_data |>
         dplyr::filter(
@@ -167,8 +167,8 @@ mod_mitigators_server <- function(id, # nolint: object_usage_linter.
             .default = NA  # if scheme is neither focal nor a peer
           )
         ) |>
-        dplyr::filter(!is.na(is_peer)) |>  # only focal scheme and peers
-        dplyr::arrange(dplyr::desc(is_peer))  # to plot focal scheme last
+        dplyr::filter(!is.na(.data$is_peer)) |>  # only focal scheme and peers
+        dplyr::arrange(dplyr::desc(.data$is_peer))  # to plot focal scheme last
     })
 
     # params controls ----

--- a/inst/app/data/ndg_variants.json
+++ b/inst/app/data/ndg_variants.json
@@ -1,7 +1,7 @@
 {
   "variant_1": {
     "variant": "variant_1",
-    "value_type": "year-on-year-growth",
+    "value-type": "year-on-year-growth",
     "values": {
       "aae": {
         "ambulance": [1.0121, 1.0142],
@@ -21,7 +21,7 @@
   },
   "variant_2": {
     "variant": "variant_2",
-    "value_type": "year-on-year-growth",
+    "value-type": "year-on-year-growth",
     "values": {
       "aae": {
         "ambulance": [1.0121, 1.0142],
@@ -41,7 +41,7 @@
   },
   "variant_3": {
     "variant": "variant_3",
-    "value_type": "year-on-year-growth",
+    "value-type": "year-on-year-growth",
     "values": {
       "aae": {
         "ambulance": [0.9946, 1.0352],


### PR DESCRIPTION
Close #412, updates #410.

* Changed underscore to hyphen in `value-type` of `ndg_variants.json` to match what is going to be interpreted by [the model](https://github.com/The-Strategy-Unit/nhp_model/pull/308).
* Added some missing `.data$` and `.env$` where needed.