### PR TITLE
Show NDG dropdown to all users, add variant to table title

### DIFF
--- a/R/mod_non_demographic_adjustment_server.R
+++ b/R/mod_non_demographic_adjustment_server.R
@@ -44,7 +44,7 @@ mod_non_demographic_adjustment_server <- function(id, params) {
     # renders ----
 
     output$non_demographic_adjustment_table <- gt::render_gt({
-      mod_non_demographic_adjustment_table(non_demographic_adjustment()[["values"]])
+      mod_non_demographic_adjustment_table(non_demographic_adjustment())
     })
   })
 }

--- a/R/mod_non_demographic_adjustment_server.R
+++ b/R/mod_non_demographic_adjustment_server.R
@@ -19,11 +19,6 @@ mod_non_demographic_adjustment_server <- function(id, params) {
     # observers ----
 
     shiny::observe({
-      can_select_variant <- is_local() || any(c("nhp_devs", "nhp_run_model") %in% session$groups)
-      shinyjs::toggle("ndg_variant_dropdown", condition = can_select_variant)
-    })
-
-    shiny::observe({
       params[["non-demographic_adjustment"]] <- non_demographic_adjustment()
     }) |>
       shiny::bindEvent(non_demographic_adjustment())

--- a/R/mod_non_demographic_adjustment_ui.R
+++ b/R/mod_non_demographic_adjustment_ui.R
@@ -22,23 +22,18 @@ mod_non_demographic_adjustment_ui <- function(id) {
         ),
         bs4Dash::box(
           title = "Non-demographic Variant",
-          md_file_to_html("app", "text", "non_demographic_adjustment_variants.md"),
           width = 12,
-          shinyjs::hidden(
-            shiny::tags$div(
-              id = ns("ndg_variant_dropdown"),
-              shiny::selectInput(
-                inputId = ns("ndg_variant"),
-                label = "Selection",
-                choices = purrr::set_names(
-                  c("variant_2", "variant_3"),
-                  snakecase::to_title_case
-                ),
-                selected = "variant_2"
-              ),
-              md_file_to_html("app", "text", "non_demographic_adjustment_variants_hidden.md")
-            )
-          )
+          md_file_to_html("app", "text", "non_demographic_adjustment_variants.md"),
+          shiny::selectInput(
+            inputId = ns("ndg_variant"),
+            label = "Selection",
+            choices = purrr::set_names(
+              c("variant_2", "variant_3"),
+              snakecase::to_title_case
+            ),
+            selected = "variant_2"
+          ),
+          md_file_to_html("app", "text", "non_demographic_adjustment_variants_hidden.md")
         )
       ),
       bs4Dash::box(
@@ -50,4 +45,3 @@ mod_non_demographic_adjustment_ui <- function(id) {
     )
   )
 }
-#

--- a/R/mod_non_demographic_adjustment_utils.R
+++ b/R/mod_non_demographic_adjustment_utils.R
@@ -1,5 +1,12 @@
 mod_non_demographic_adjustment_table <- function(non_demographic_adjustment) {
-  non_demographic_adjustment |>
+
+  title <- switch(
+    non_demographic_adjustment[["variant"]],
+    "variant_2" = "Variant 2 (primary rate)",
+    "variant_3" = "Variant 3 (for sensitivity only)"
+  )
+
+  non_demographic_adjustment[["values"]] |>
     purrr::map_depth(2, ~ purrr::set_names(.x, c("low", "high"))) |>
     purrr::map(tibble::enframe) |>
     dplyr::bind_rows(.id = "activity_type") |>
@@ -29,7 +36,8 @@ mod_non_demographic_adjustment_table <- function(non_demographic_adjustment) {
       row_group.border.top.color = "black",
       row_group.border.bottom.color = "black",
       row_group.background.color = "#686f73"
-    )
+    ) |>
+    gt::tab_header(title)
 }
 
 nda_groups <- list(


### PR DESCRIPTION
Close #419, close #420.

* Removed logic that hid the NDG dropdown box from users that weren't in the nhp_run_model Connect group (all users can now see the dropdown and associated text).
* Added a conditional table title to the NDG values table.

Example of table title:

![image](https://github.com/user-attachments/assets/33404dd4-ef28-43e2-8ea4-1d531b3a0524)

Note that supporting text is to be updated separately when confirmed in #404.