### PR TITLE
Prefer to show the end year from params as the 'model financial year'

### DIFF
--- a/app.R
+++ b/app.R
@@ -464,22 +464,33 @@ server <- function(input, output, session) {
   }) |>
     shiny::bindEvent(selected_providers())
 
-  # the end-year range should be 1 year after the start year to the year 2043,
-  # which will also be the default.
+  # the end-year range should be 1 year after the start year to the year 2041/42,
+  # which will also be the default if starting from scratch.
   shiny::observe({
-    x <- as.numeric(stringr::str_sub(input$start_year, 1, 4))
+    start_yr <- as.numeric(stringr::str_sub(input$start_year, 1, 4))  #
 
-    fy_yyyy <- seq(x + 1, 2041) # 2043 fixed as latest possible end year
+    fy_yyyy <- seq(start_yr + 1, 2041)  # sequence from start+1 to end year
     fy_yy <- stringr::str_sub(fy_yyyy + 1, 3, 4)
     fy_choices <- paste(fy_yyyy, fy_yy, sep = "/")
     fy_choices_num <- setNames(fy_yyyy, fy_choices)
 
-    shiny::updateSelectInput(
-      session,
-      "end_year",
-      choices = fy_choices_num,
-      selected = max(fy_choices_num)
-    )
+    # Set end year to latest year, otherwise the year stored in existing params
+    if (input$scenario_type == "Create new from scratch") {
+      shiny::updateSelectInput(
+        session,
+        "end_year",
+        choices = fy_choices_num,
+        selected = max(fy_choices_num)
+      )
+    } else {
+      p <- shiny::req(params())
+      shiny::updateSelectInput(
+        session,
+        "end_year",
+        choices = fy_choices_num,
+        selected = p$end_year
+      )
+    }
   }) |>
     shiny::bindEvent(input$start_year)
 


### PR DESCRIPTION
Close #437.

* Updated logic for displaying the end year in the 'model financial year' dropdown:
  - if creating a new scenario, default to the latest year (2041)
  - if using existing scenarios, read the `end_year` from params (which fixes the bug)
* Tweaked some comments for clarity.

If I choose an existing scenario where I've got non-default start and end years, the dropdowns update to match:

![Screenshot 2025-03-21 143307](https://github.com/user-attachments/assets/ba9b32ce-7d30-4356-83d2-7b03a7c175e1)

When returning to create new from scratch, the defaults are returned in the dropdowns:

![Screenshot 2025-03-21 143430](https://github.com/user-attachments/assets/77d980cd-4f9b-4249-8966-f3fd34fa0008)