### PR TITLE
Ensure 'start' is shown when creating new from scratch

### DIFF
--- a/app.R
+++ b/app.R
@@ -563,6 +563,7 @@ server <- function(input, output, session) {
   # If scenario has NDG variant 1 then it cannot be updated because model v3.3
   # does not accept variant 1.
   shiny::observe({
+    # Toggle element visibility if selecting existing scenarios
     if (stringr::str_detect(input$scenario_type, "existing")) {
 
       p <- shiny::req(params())
@@ -580,6 +581,13 @@ server <- function(input, output, session) {
         shinyjs::show("start_button")
       }
 
+    }
+
+    # Reset element visibility if starting from scratch
+    if (input$scenario_type == "Create new from scratch") {
+      shinyjs::hide("ndg_warning")
+      shinyjs::enable("scenario")
+      shinyjs::show("start_button")
     }
   }) |>
     shiny::bindEvent(


### PR DESCRIPTION
Close #435.

* Added logic to ensure start button is shown if creating a new scenario from scratch (and a valid scenario name is entered), regardless of whether an NDG1 scenario had been selected previously from 'existing' radio button options.