### PR TITLE
Upgrade for v3.4 by removing AEC mitigators from params

### DIFF
--- a/app.R
+++ b/app.R
@@ -55,6 +55,7 @@ upgrade_params.v3.1 <- function(p) {
 }
 
 upgrade_params.v3.2 <- function(p) {
+  # Change NDG params structure
 
   ndg_values <- p[["non-demographic_adjustment"]]
 
@@ -70,6 +71,24 @@ upgrade_params.v3.2 <- function(p) {
   if (is_ndg1) p[["non-demographic_adjustment"]][["variant"]] <- "variant_1"
 
   class(p) <- p$app_version <- "v3.3"
+  upgrade_params(p)
+}
+
+upgrade_params.v3.3 <- function(p) {
+  # Remove deprecated AEC mitigators
+
+  aec_mitigators <- paste0(
+    "ambulatory_emergency_care_",
+    c("low", "moderate", "high", "very_high")
+  )
+
+  for (mitigator in aec_mitigators) {
+    p[["efficiencies"]][["ip"]][[mitigator]] <- NULL
+    p[["time_profile_mappings"]][["efficiencies"]][["ip"]][[mitigator]] <- NULL
+    p[["reasons"]][["efficiencies"]][["ip"]][[mitigator]] <- NULL
+  }
+
+  class(p) <- p$app_version <- "v3.4"
   upgrade_params(p)
 }
 
@@ -573,7 +592,7 @@ server <- function(input, output, session) {
 
   # If scenario has NDG variant 1 then it cannot be updated because model v3.3
   # does not accept variant 1.
-shiny::observe({
+  shiny::observe({
     # Toggle element visibility if selecting existing scenarios
     if (stringr::str_detect(input$scenario_type, "existing")) {
 

--- a/deploy.R
+++ b/deploy.R
@@ -40,6 +40,7 @@ deploy <- function(server, app_id, app_version_choices) {
 }
 
 app_version_choices <- c(
+  "v3.4",
   "v3.3",
   "v3.2",
   "v3.1",


### PR DESCRIPTION
Close #453.

* On upgrade to v3.4, set AEC-mitigator list-elements (efficiencies, time-profile mappings and reasons) to `NULL`, thereby deleting them.
* Include v3.4 in the deploy script's list of versions.