### PR TITLE
Correct typo when removing 'file' key from params

### DIFF
--- a/app.R
+++ b/app.R
@@ -95,8 +95,8 @@ upgrade_params.v3.3 <- function(p) {
   }
 
   # remove the unused demographics file key
-  if ("demographic_factors" %in% names(p$demographic_factors)) {
-    p$demographic_factors$file <- NULL
+  if ("file" %in% names(p[["demographic_factors"]])) {
+    p[["demographic_factors"]][["file"]] <- NULL
   }
 
   class(p) <- p$app_version <- "v3.4"


### PR DESCRIPTION
Actually closes #460, following #466.

* `"demographic_factors"` should be `"file"` in the `if` statement (I failed to spot this earlier).
* Added square brackets for safety/consistency.