### PR TITLE
Upgrade to insert inequalities

### DIFF
--- a/app.R
+++ b/app.R
@@ -108,7 +108,7 @@ upgrade_params.v3.4 <- function(p) {
 
   p <- modifyList(
     p,
-    list(inequalities = NULL),  # model expects 'inequalities: null'
+    list(inequalities = NULL),  # model expects "inequalities": {}
     keep.null = TRUE  # NULL list elements are usually discarded
   )
 

--- a/app.R
+++ b/app.R
@@ -103,6 +103,19 @@ upgrade_params.v3.3 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v3.4 <- function(p) {
+  # Add (or overwrite) inequalities
+
+  p <- modifyList(
+    p,
+    list(inequalities = NULL),  # model expects 'inequalities: null'
+    keep.null = TRUE  # NULL list elements are usually discarded
+  )
+
+  class(p) <- p$app_version <- "v3.5"
+  upgrade_params(p)
+}
+
 params_path <- function(user, dataset) {
   path <- file.path(
     config::get("params_data_path"),

--- a/default_params.json
+++ b/default_params.json
@@ -13,6 +13,7 @@
     }
   },
   "health_status_adjustment": true,
+  "inequalities": {},
   "covid_adjustment": {
     "aae": {},
     "ip": {},

--- a/deploy.R
+++ b/deploy.R
@@ -40,6 +40,7 @@ deploy <- function(server, app_id, app_version_choices) {
 }
 
 app_version_choices <- c(
+  "v3.5",
   "v3.4",
   "v3.3",
   "v3.2",
@@ -62,6 +63,7 @@ deploy(
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v3.5",
   "v3.4",
   "v3.3",
   "dev"


### PR DESCRIPTION
Close #476.

* Add `upgrade_params.v3.4()` method to insert empty 'inequalities' dict to params json.
* Add inequalities key into `default_params.json`.
* Add v3.5 to deploy script.

Tested new and new-from-existing locally on a 3.4 scenario and both resulted in `"inequalities": {}` in their params.