### PR TITLE
adds custom variants

### DIFF
--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -291,3 +291,55 @@ production:
   params_data_path: "/data/nhp/prod/inputs"
 dev:
   golem_wd: !expr here::here()
+dataset_R0A:
+  population_projections:
+    values:
+      custom_projection_R0A66: North Manchester Variant
+    subset:
+      - custom_projection_R0A66
+      - principal_proj
+      - var_proj_10_year_migration
+      - var_proj_alt_internal_migration
+      - var_proj_high_intl_migration
+      - var_proj_low_intl_migration
+      - const_fertility_no_mortality_improvement
+      - const_fertility
+      - high_population
+      - young_age_structure
+      - high_fertility
+      - old_age_structure
+      - low_population
+      - low_fertility
+      - high_life_expectancy
+      - low_life_expectancy
+      - no_mortality_improvement
+      - zero_eu_migration
+      - half_eu_migration
+      - zero_net_migration
+      - replacement_fertility
+dataset_RD8:
+  population_projections:
+    values:
+      custom_projection_RD8: Milton Keynes Variant
+    subset:
+      - custom_projection_RD8
+      - principal_proj
+      - var_proj_10_year_migration
+      - var_proj_alt_internal_migration
+      - var_proj_high_intl_migration
+      - var_proj_low_intl_migration
+      - const_fertility_no_mortality_improvement
+      - const_fertility
+      - high_population
+      - young_age_structure
+      - high_fertility
+      - old_age_structure
+      - low_population
+      - low_fertility
+      - high_life_expectancy
+      - low_life_expectancy
+      - no_mortality_improvement
+      - zero_eu_migration
+      - half_eu_migration
+      - zero_net_migration
+      - replacement_fertility


### PR DESCRIPTION
- closes #472
- closes #494

for both Manchester and Milton Keynes, adds their custom population variants as the default options.
leaves all the other projections in place, but with a value of 0 by default.

if using existing scenarios, then they will continue to use the previously selected (probably principal) projection values and will need to be manually edited.

new scenarios will need the default params in the inputs selection app to be changed - will handle that separately.
