### PR TITLE
removes the default values for demographic_factors

### DIFF
--- a/default_params.json
+++ b/default_params.json
@@ -7,11 +7,7 @@
   "start_year": 2019,
   "end_year": 2041,
   "app_version": null,
-  "demographic_factors": {
-    "variant_probabilities": {
-      "principal_proj": 1
-    }
-  },
+  "demographic_factors": {},
   "health_status_adjustment": true,
   "inequalities": {},
   "covid_adjustment": {


### PR DESCRIPTION
these get set by the inputs app, but if we have custom projections (which appear above principal projection), these were not by default selected when we had a value set for the principal projection.

removing the default values allows the inputs app to select as appropriate