### PR TITLE
Upgrade to v3.6, overwrite waiting list adjustment

### DIFF
--- a/app.R
+++ b/app.R
@@ -108,11 +108,21 @@ upgrade_params.v3.4 <- function(p) {
 
   p <- modifyList(
     p,
-    list(inequalities = NULL),  # model expects "inequalities": {}
-    keep.null = TRUE  # NULL list elements are usually discarded
+    list(inequalities = NULL), # model expects "inequalities": {}
+    keep.null = TRUE # NULL list elements are usually discarded
   )
 
   class(p) <- p$app_version <- "v3.5"
+  upgrade_params(p)
+}
+
+upgrade_params.v3.5 <- function(p) {
+  # Set waiting list adjustment to 'off'
+
+  p[["waiting_list_adjustment"]]["ip"] <- list(NULL)
+  p[["waiting_list_adjustment"]]["op"] <- list(NULL)
+
+  class(p) <- p$app_version <- "v3.6"
   upgrade_params(p)
 }
 

--- a/deploy.R
+++ b/deploy.R
@@ -40,6 +40,7 @@ deploy <- function(server, app_id, app_version_choices) {
 }
 
 app_version_choices <- c(
+  "v3.6",
   "v3.5",
   "v3.4",
   "v3.3",
@@ -63,6 +64,7 @@ deploy(
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v3.6",
   "v3.5",
   "v3.4",
   "v3.3",


### PR DESCRIPTION
Close #503. Counterpart to #504.

* Create an upgrade step for v3.6 that sets `waiting_list_adjustment` to an empty list for its `ip` and `op` elements.
* Add v3.6 to app version choices.