### PR TITLE
Upgrade to remove unused mitigators, deploy to new server only

### DIFF
--- a/app.R
+++ b/app.R
@@ -133,6 +133,26 @@ upgrade_params.v3.5 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v3.6 <- function(p) {
+  # Remove renamed day-procedure mitigators
+
+  day_procedures_mitigators <- c(
+    "bads_daycase",
+    "bads_daycase_occasional",
+    "bads_outpatients",
+    "bads_outpatients_or_daycase"
+  )
+
+  for (mitigator in day_procedures_mitigators) {
+    p[["efficiencies"]][["ip"]][[mitigator]] <- NULL
+    p[["time_profile_mappings"]][["efficiencies"]][["ip"]][[mitigator]] <- NULL
+    p[["reasons"]][["efficiencies"]][["ip"]][[mitigator]] <- NULL
+  }
+
+  class(p) <- p$app_version <- "v3.7"
+  upgrade_params(p)
+}
+
 params_path <- function(user, dataset) {
   path <- file.path(
     config::get("params_data_path"),

--- a/deploy.R
+++ b/deploy.R
@@ -39,40 +39,18 @@ deploy <- function(server, app_id, app_version_choices) {
   )
 }
 
+# only use the versions that are deployed to the server currently
 app_version_choices <- c(
+  "v3.7",
   "v3.6",
   "v3.5",
   "v3.4",
   "v3.3",
-  "v3.2",
-  "v3.1",
-  "v3.0",
-  "v2.2",
-  "v2.1",
-  "v2.0",
-  "v1.2",
-  "v1.1",
-  "v1.0",
   "dev"
 )
 
 deploy(
   server = "connect.strategyunitwm.nhs.uk",
-  app_id = 215,
-  app_version_choices
-)
-
-# only use the versions that are deployed to the new server currently
-app_version_choices <- c(
-  "v3.6",
-  "v3.5",
-  "v3.4",
-  "v3.3",
-  "dev"
-)
-
-deploy(
-  server = "connect.su.mlcsu.org",
   app_id = 71,
   app_version_choices
 )


### PR DESCRIPTION
Close #517.

* Added upgrade step and deploy-app version choices for v3.7.
* The upgrade step removes mitigators that were renamed to 'day procedures' (same upgrade process as for the AEC deprecation), which was triggering the json schema validation in the model.
* Deploy only to the new server.

This feels low risk/minimal effort, but happy to reconsider if you think maybe it is better to find and manually adjust these on the server? 