### PR TITLE
Prevent scenario development if baseline is <2023, warn about pop upgrade

### DIFF
--- a/app.R
+++ b/app.R
@@ -5,7 +5,7 @@ app_version_choices <- jsonlite::fromJSON(Sys.getenv(
 
 # CONSTANTS ----
 maximum_model_horizon_year <- 2041
-default_baseline_year <- 2019
+default_baseline_year <- 2023
 
 # HELPERS ----
 
@@ -251,7 +251,7 @@ ui_body <- function() {
         "start_year",
         "Baseline Financial Year",
         # TODO: revisit why start year and end year are formatted differently
-        choices = c("2019/20" = 201920, "2023/24" = 202324),
+        choices = c("2023/24" = 202324),
         selected = as.character(
           (default_baseline_year * 100) + ((default_baseline_year + 1) %% 100)
         )
@@ -293,8 +293,8 @@ ui_body <- function() {
         shiny::div(
           id = "start_year_warning",
           shiny::HTML(
-            "<font color='red'>You cannot upgrade a scenario that contains
-            a start year prior to 2023/24. See
+            "<font color='red'>The selected scenario has a baseline year prior
+            to 2023/24 and cannot be upgraded. See
             <a href='https://connect.strategyunitwm.nhs.uk/nhp/project_information/project_plan_and_summary/model_updates.html#v4.0'>
             the model updates page</a> for details.</font>"
           )
@@ -557,16 +557,6 @@ server <- function(input, output, session) {
       shinyjs::enable("selected_user")
       shinyjs::show("selected_user")
     }
-
-    if (
-      is_local() || is_power_user || "nhp_allow_2022_data" %in% session$groups
-    ) {
-      shiny::updateSelectInput(
-        session,
-        "start_year",
-        choices = c("2019/20" = 201920, "2022/23" = 202223, "2023/24" = 202324)
-      )
-    }
   })
 
   # when params change, update inputs
@@ -577,11 +567,6 @@ server <- function(input, output, session) {
       "start_year is coming through as an fyear, should be yyyy" =
         (p$start_year >= 1000) && (p$start_year <= 9999) # fmt:skip
     )
-
-    y <- p$start_year * 100 + p$start_year %% 100 + 1
-    # we don't need to update dataset:
-    # the parameters files that are listed in the previous scenario dropdown are already tied to that provider
-    shiny::updateSelectInput(session, "start_year", selected = y)
 
     selected_end_year <- p$end_year
     if (

--- a/deploy.R
+++ b/deploy.R
@@ -39,40 +39,18 @@ deploy <- function(server, app_id, app_version_choices) {
   )
 }
 
+# only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v4.0",
   "v3.6",
   "v3.5",
   "v3.4",
   "v3.3",
-  "v3.2",
-  "v3.1",
-  "v3.0",
-  "v2.2",
-  "v2.1",
-  "v2.0",
-  "v1.2",
-  "v1.1",
-  "v1.0",
   "dev"
 )
 
 deploy(
   server = "connect.strategyunitwm.nhs.uk",
-  app_id = 215,
-  app_version_choices
-)
-
-# only use the versions that are deployed to the new server currently
-app_version_choices <- c(
-  "v3.6",
-  "v3.5",
-  "v3.4",
-  "v3.3",
-  "dev"
-)
-
-deploy(
-  server = "connect.su.mlcsu.org",
   app_id = 71,
   app_version_choices
 )

--- a/home.md
+++ b/home.md
@@ -1,8 +1,12 @@
-**Please Note**: By accessing this model you are acknowledging that you are aware of the implications of setting the model parameters, and have completed any relevant training. If this is not the case, please contact your Model Relationship Manager, or contact [the data science team](mlcsu.su.datascience@nhs.net) before proceeding.
+**Please Note**: By accessing this model you are acknowledging that you are aware of the implications of setting the model parameters, and have completed any relevant training.
+If this is not the case, please contact your Model Relationship Manager, or contact [the data science team](mlcsu.su.datascience@nhs.net) before proceeding.
 
-Changing the provider will update all of the information shown within the inputs application. You will immediately see the map update showing the selected provider, as well as that trusts peers, as defined by the [Trust Peer Finder Tool](https://app.powerbi.com/view?r=eyJrIjoiMjdiOWQ4YTktNmNiNC00MmIwLThjNzktNWVmMmJmMzllNmViIiwidCI6IjUwZjYwNzFmLWJiZmUtNDAxYS04ODAzLTY3Mzc0OGU2MjllMiIsImMiOjh9). The list of these peers is displayed below the map (collapsed by default). Clicking on any of the points on the map will reveal the name of the provider.
+Changing the provider will update all of the information shown within the inputs application.
+You will immediately see the map update showing the selected provider, as well as that trusts peers, as defined by the [Trust Peer Finder Tool](https://app.powerbi.com/view?r=eyJrIjoiMjdiOWQ4YTktNmNiNC00MmIwLThjNzktNWVmMmJmMzllNmViIiwidCI6IjUwZjYwNzFmLWJiZmUtNDAxYS04ODAzLTY3Mzc0OGU2MjllMiIsImMiOjh9). The list of these peers is displayed below the map (collapsed by default).
+Clicking on any of the points on the map will reveal the name of the provider.
 
-Once you have chosen a provider, you can pick from one of the baseline years, and then select the year that you want to use as the model horizon. This defaults to 15 years from the baseline.
+Once you have chosen a provider, you can pick from one of the baseline years (currently only 2023/24), and then select the year that you want to use as the model horizon.
+This defaults to 2041/42.
 
 Finally, you must specify a scenario name - this will be how the results are identified in the inputs app.
 
@@ -10,11 +14,14 @@ To run a model with your given parameters, you must contact [the data science te
 
 ## Evidence Map
 
-Much evidence exists in published literature of the efficacy of various methods to reduce or avoid acute hospital demand. Although difficult to summarise, we have mapped this evidence in [an interactive app](https://connect.strategyunitwm.nhs.uk/nhp_evidence_map/) to provide an overview, categorised by setting, evidence type, outcomes and effect. This map is provided to enable exploration of the current evidence landscape, identify gaps in knowledge, and allow searching of evidence by a range of parameters.
+Much evidence exists in published literature of the efficacy of various methods to reduce or avoid acute hospital demand.
+Although difficult to summarise, we have mapped this evidence in [an interactive app](https://connect.strategyunitwm.nhs.uk/nhp_evidence_map/) to provide an overview, categorised by setting, evidence type, outcomes and effect.
+This map is provided to enable exploration of the current evidence landscape, identify gaps in knowledge, and allow searching of evidence by a range of parameters.
 
 ## Advanced Options
 
-By default, these are hidden. There are two options that can be adjusted here:
+By default, these are hidden.
+There are two options that can be adjusted here:
 
--   The random seed used for the model run. This defaults to a random value each time, but can be set to a specific value to repeat a prior model run
+-   The random seed used for the model run. This defaults to a random value each time, but can be set to a specific value to repeat a prior model run.
 -   The number of iterations to use within the Monte-Carlo simulation. This defaults to 256 runs, but can be set to 512 or 1024 runs.


### PR DESCRIPTION
Close #519. Replaces #521. Counterpart to #520.

* Warn about population-projection upgrade if scenario <v4.0.
* Remove inputs and warn user if baseline year <2023 (supersedes pop-projection upgrade).
* Allow only 2023/24 in the baseline-year dropdown.
* Deploy to new server only, include v4.0 in app versions.

## Quick tests

I made three scenarios with different combinations of `start_year` (baseline year) and `app_version` to make sure the warnings fired as expected.

Baseline <2023, version <4.0 (baseline warning supersedes upgrade warning):

![image](https://github.com/user-attachments/assets/9ceb9374-0e93-40ec-aae1-ddfd8436fe61)

Baseline <2023, version == 4.0 (baseline warning only):

![image](https://github.com/user-attachments/assets/d539e143-e5c6-4cf3-98cc-ab7015fb3347)

Baseline == 2023, version <4.0 (upgrade warning only):

![image](https://github.com/user-attachments/assets/a9adc37f-ad29-4602-a16d-d269cb63d9ee)

Baseline == 2023, version == 4.0 (no warnings):

![image](https://github.com/user-attachments/assets/26655724-8f5c-4883-88bc-f87ad8b3b83c)
