### PR TITLE
Provide text instead of top-6 OP diagnoses table

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -238,25 +238,31 @@ app_ui <- function(request) {
         tabName = "op_am_c2c_referrals",
         mod_mitigators_ui(
           "mitigators_op_c2c_reduction",
-          "Consultant to Consultant Reduction"
+          "Consultant to Consultant Reduction",
+          FALSE
         )
       ),
       bs4Dash::tabItem(
         tabName = "op_am_convert_tele",
         mod_mitigators_ui(
           "mitigators_op_convert_tele",
-          "Convert to Tele Appointment"
+          "Convert to Tele Appointment",
+          FALSE
         )
       ),
       bs4Dash::tabItem(
         tabName = "op_am_fup_reduction",
-        mod_mitigators_ui("mitigators_op_fup_reduction", "Follow-Up Reduction")
+        mod_mitigators_ui(
+          "mitigators_op_fup_reduction",
+          "Follow-Up Reduction",
+          FALSE)
       ),
       bs4Dash::tabItem(
         tabName = "op_gp_referred_first_attendance_reduction",
         mod_mitigators_ui(
           "mitigators_op_gp_referred_first_attendance_reduction",
-          "GP Referred First Attendances"
+          "GP Referred First Attendances",
+          FALSE
         )
       ),
       bs4Dash::tabItem(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -263,7 +263,7 @@ app_ui <- function(request) {
         mod_mitigators_ui(
           "mitigators_op_gp_referred_first_attendance_reduction",
           "GP Referred First Attendances",
-          FALSE
+          show_diagnoses_table = FALSE
         )
       ),
       bs4Dash::tabItem(

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -255,7 +255,8 @@ app_ui <- function(request) {
         mod_mitigators_ui(
           "mitigators_op_fup_reduction",
           "Follow-Up Reduction",
-          FALSE)
+          FALSE
+        )
       ),
       bs4Dash::tabItem(
         tabName = "op_gp_referred_first_attendance_reduction",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -239,7 +239,7 @@ app_ui <- function(request) {
         mod_mitigators_ui(
           "mitigators_op_c2c_reduction",
           "Consultant to Consultant Reduction",
-          FALSE
+          show_diagnoses_table = FALSE
         )
       ),
       bs4Dash::tabItem(
@@ -247,7 +247,7 @@ app_ui <- function(request) {
         mod_mitigators_ui(
           "mitigators_op_convert_tele",
           "Convert to Tele Appointment",
-          FALSE
+          show_diagnoses_table = FALSE
         )
       ),
       bs4Dash::tabItem(
@@ -255,7 +255,7 @@ app_ui <- function(request) {
         mod_mitigators_ui(
           "mitigators_op_fup_reduction",
           "Follow-Up Reduction",
-          FALSE
+          show_diagnoses_table = FALSE
         )
       ),
       bs4Dash::tabItem(

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -76,7 +76,7 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
             width = 2
           ),
           col_6(
-            if(show_diagnoses_table){
+            if (show_diagnoses_table) {
               bs4Dash::box(
                 title = "Top 6 Primary Diagnoses",
                 shinycssloaders::withSpinner({
@@ -92,7 +92,7 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
               }),
               width = 12
             )
-            ),
+          ),
           bs4Dash::box(
             title = "Bar Chart of Activity by Age and Sex",
             shinycssloaders::withSpinner({

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -82,9 +82,9 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
                 shinycssloaders::withSpinner({
                   gt::gt_output(ns("diagnoses_table"))
                 })
-                }else{
-                  shiny::p("No diagnosis data for Outpatients")
-                },
+              } else {
+                shiny::p("No diagnosis data for Outpatients")
+              },
               width = 12
             ),
             bs4Dash::box(

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -7,7 +7,7 @@
 #' @noRd
 #'
 #' @importFrom shiny NS tagList
-mod_mitigators_ui <- function(id, title) {
+mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
   ns <- shiny::NS(id)
   shiny::tagList(
     shiny::h1("Activity Mitigators"),
@@ -75,27 +75,31 @@ mod_mitigators_ui <- function(id, title) {
             }),
             width = 2
           ),
-          bs4Dash::box(
-            title = "Top 6 Primary Diagnoses",
-            shinycssloaders::withSpinner({
-              gt::gt_output(ns("diagnoses_table"))
-            }),
-            width = 6
-          ),
+          col_6(
+            if(show_diagnoses_table){
+              bs4Dash::box(
+                title = "Top 6 Primary Diagnoses",
+                shinycssloaders::withSpinner({
+                  gt::gt_output(ns("diagnoses_table"))
+                }),
+                width = 12
+              )
+            },
+            bs4Dash::box(
+              title = "Breakdown by Procedure",
+              shinycssloaders::withSpinner({
+                gt::gt_output(ns("procedures_table"))
+              }),
+              width = 12
+            )
+            ),
           bs4Dash::box(
             title = "Bar Chart of Activity by Age and Sex",
             shinycssloaders::withSpinner({
               shiny::plotOutput(ns("age_grp_plot"))
             }),
             width = 6
-          ),
-          bs4Dash::box(
-            title = "Breakdown by Procedure",
-            shinycssloaders::withSpinner({
-              gt::gt_output(ns("procedures_table"))
-            }),
-            width = 6
-          ),
+          )
         )
       )
     )

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -76,15 +76,17 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
             width = 2
           ),
           col_6(
-            if (show_diagnoses_table) {
-              bs4Dash::box(
-                title = "Top 6 Primary Diagnoses",
+            bs4Dash::box(
+              title = "Top 6 Primary Diagnoses",
+              if (show_diagnoses_table) {
                 shinycssloaders::withSpinner({
                   gt::gt_output(ns("diagnoses_table"))
-                }),
-                width = 12
-              )
-            },
+                })
+                }else{
+                  shiny::p("No diagnosis data for Outpatients")
+                },
+              width = 12
+            ),
             bs4Dash::box(
               title = "Breakdown by Procedure",
               shinycssloaders::withSpinner({

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -83,7 +83,7 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
                   gt::gt_output(ns("diagnoses_table"))
                 })
               } else {
-                shiny::p("No diagnosis data for Outpatients")
+                shiny::p("No diagnosis data for outpatients.")
               },
               width = 12
             ),


### PR DESCRIPTION
For the Outpatient Activity Mitigators the Top 6 Primary Diagnoses table will now show a message indicating that diagnosis data is unavailable for Outpatients. 

Other mitigators will remain unchanged.