### PR TITLE
Upgrade to remove covid in selection app

### DIFF
--- a/app.R
+++ b/app.R
@@ -150,6 +150,15 @@ upgrade_params.v3.6 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v4.0 <- function(p) {
+  # Remove covid adjustment
+
+  p[["covid_adjustment"]] <- NULL
+
+  class(p) <- p$app_version <- "v4.1"
+  upgrade_params(p)
+}
+
 params_path <- function(user, dataset) {
   path <- file.path(
     config::get("params_data_path"),

--- a/default_params.json
+++ b/default_params.json
@@ -10,11 +10,6 @@
   "demographic_factors": {},
   "health_status_adjustment": true,
   "inequalities": {},
-  "covid_adjustment": {
-    "aae": {},
-    "ip": {},
-    "op": {}
-  },
   "expat": {
     "ip": {},
     "op": {},

--- a/deploy.R
+++ b/deploy.R
@@ -41,6 +41,7 @@ deploy <- function(server, app_id, app_version_choices) {
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v4.1",
   "v4.0",
   "v3.6",
   "v3.5",


### PR DESCRIPTION
Close #562.

* Added `upgrade_params.v4.0()` method to remove covid adjustment from params.
* Added v4.1 to the app version choices.
* Removed covid from default params.