### PR TITLE
Add placeholder text in rationale boxes

### DIFF
--- a/R/mod_reasons_ui.R
+++ b/R/mod_reasons_ui.R
@@ -15,7 +15,11 @@ mod_reasons_ui <- function(id) {
     shiny::textAreaInput(
       ns("value"),
       NULL,
-      height = "200px"
+      height = "200px",
+      placeholder = paste(
+        "Type your rationale here and it will be saved automatically.",
+        "You can supply reasons for your choices even if you don't make changes."
+      )
     )
   )
 }


### PR DESCRIPTION
Close #411.

* Added placeholder text into rationale boxes (see [comment](https://github.com/The-Strategy-Unit/nhp_inputs/issues/411#issuecomment-3197914800) for reasoning behind).

<img width="300" src="https://github.com/user-attachments/assets/37516cdb-e3c0-4f19-bded-c98caeb38241" />

@StatsRhian: I'm particularly interested in your thoughts on the wording and the placement of the text as a placeholder _inside_ the box (rather than as a paragraph above or below the box).