### PR TITLE
Remove covid adjustment from time-profile mappings

### DIFF
--- a/app.R
+++ b/app.R
@@ -156,6 +156,7 @@ upgrade_params.v4.0 <- function(p) {
   # Remove covid adjustment
 
   p[["covid_adjustment"]] <- NULL
+  p[["time_profile_mappings"]][["covid_adjustment"]] <- NULL
 
   class(p) <- p$app_version <- "v4.1"
   upgrade_params(p)

--- a/default_params.json
+++ b/default_params.json
@@ -49,7 +49,6 @@
     "op": {}
   },
   "time_profile_mappings": {
-    "covid_adjustment": "none",
     "baseline_adjustment": "none",
     "activity_avoidance": {
       "ip": {},


### PR DESCRIPTION
Close #572.

* Removed covid adjustment from default params, under time-profile mappings.
* Added to the upgrade step to remove covid adjustment from time-profile mappings.