### PR TITLE
Ignore inequalities in recursive nullification

### DIFF
--- a/R/mod_run_model_fix_params.R
+++ b/R/mod_run_model_fix_params.R
@@ -42,7 +42,11 @@ mod_run_model_fix_params <- function(p, schema_text) {
   # nolint end
   recursive_nullify <- function(.x) {
     for (i in names(.x)) {
-      if (length(.x[[i]]) == 0) {
+      if (
+        # an empty json list is OK for inequalities, so ignore
+        !i %in% c("level_down", "zero_sum", "level_up") &&
+          length(.x[[i]]) == 0
+      ) {
         .x[i] <- list(NULL)
       } else {
         .x[[i]] <- recursive_nullify(.x[[i]])


### PR DESCRIPTION
Close #582.

Ignore potentially-empty inequalities keys (level_down, zero_sum, level_up) when recursively converting empty params elements.

As evidence, empty inequalities elements are retained as empty json lists when revealed in the 'view params' section of the 'run model' module:

<img width="300" src="https://github.com/user-attachments/assets/1c0b729d-745f-49be-992d-2157381e6a8b" />
