### PR TITLE
Revert to empty inequalities dict

### DIFF
--- a/app.R
+++ b/app.R
@@ -163,14 +163,6 @@ upgrade_params.v4.0 <- function(p) {
 }
 
 upgrade_params.v4.1 <- function(p) {
-  # Update structure of the inequalities key to include strategy choices
-
-  p[["inequalities"]] <- list(
-    level_up = list(), # empty [] in output json
-    zero_sum = list(),
-    level_down = list()
-  )
-
   class(p) <- p$app_version <- "v4.2"
   upgrade_params(p)
 }

--- a/default_params.json
+++ b/default_params.json
@@ -9,11 +9,7 @@
   "app_version": null,
   "demographic_factors": {},
   "health_status_adjustment": true,
-  "inequalities": {
-    "level_up": [],
-    "zero_sum": [],
-    "level_down": []
-  },
+  "inequalities": {},
   "expat": {
     "ip": {},
     "op": {},


### PR DESCRIPTION
Close #584.

* Revert to empty dict for inequalities in default params.
* Remove upgrade steps (but keep upgrade method).

This is the change required for the selection app.