### PR TITLE
Add feedback form URL secret to action

### DIFF
--- a/.github/workflows/connect-publish-manual.yaml
+++ b/.github/workflows/connect-publish-manual.yaml
@@ -50,6 +50,7 @@ jobs:
           CONNECT_ENV_SET_NHP_ENCRYPT_KEY: ${{ secrets.NHP_ENCRYPT_KEY }}
           CONNECT_ENV_SET_NHP_INPUTS_DATA_VERSION: ${{ inputs.inputs_data_version }}
           CONNECT_ENV_SET_NHP_OUTPUTS_URI: ${{ secrets.NHP_OUTPUTS_URI }}
+          CONNECT_ENV_SET_FEEDBACK_FORM_URL: ${{ secrets.FEEDBACK_FORM_URL }}
           CONNECT_ENV_SET_GOLEM_CONFIG_ACTIVE: "production"
         with:
           url: ${{ secrets.RSCONNECT_URL }}


### PR DESCRIPTION
Close #605.

* Added `FEEDBACK_FORM_URL` to repo secrets.
* Set this env var in the deploy action.