### PR TITLE
patch to use new rates data structure

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -70,6 +70,7 @@ app_server <- function(input, output, session) {
       )
 
     rates |>
+      dplyr::filter(.data$provider != "national") |>
       dplyr::inner_join(national_rate, by = c("fyear", "strategy"))
   }) |>
     shiny::bindCache(cache_version())


### PR DESCRIPTION
reshapes the data to match the column/row structure for rates.parquet, so no other code needs to change.

we might want to update the code to use the new column names longterm rather than patching
