### PR TITLE
:bug: Fix params.json filename

### DIFF
--- a/R/mod_run_model_server.R
+++ b/R/mod_run_model_server.R
@@ -114,7 +114,7 @@ mod_run_model_server <- function(id, params, schema_text) {
     # instead of the intended content. we handle this by disabling the button
     # until the params are ready
     output$download_params <- shiny::downloadHandler(
-      filename = \() paste0(fixed_params()$id, ".json"),
+      filename = \() paste0(fixed_params()$scenario, ".json"),
       content = \(file) {
         readr::write_lines(params_json(), file)
       }


### PR DESCRIPTION
Closes #609 

`fixed_params()` does not have an element called `id`. 

The most relevant I could find is `scenario`.

We _could_ construct something which also includes `dataset` but I think this is sufficient for now.

Tested on edit from existing, and new scenario.

![609](https://github.com/user-attachments/assets/2a2cdcb6-9e91-4df8-913d-060fffe4123f)
