### PR TITLE
Update inputs selection app for v4.4

### DIFF
--- a/app.R
+++ b/app.R
@@ -172,6 +172,11 @@ upgrade_params.v4.2 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v4.3 <- function(p) {
+  class(p) <- p$app_version <- "v4.4"
+  upgrade_params(p)
+}
+
 params_path <- function(user, dataset) {
   path <- file.path(
     config::get("params_data_path"),

--- a/deploy.R
+++ b/deploy.R
@@ -41,6 +41,7 @@ deploy <- function(server, app_id, app_version_choices) {
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v4.4",
   "v4.3",
   "v4.2",
   "v4.1",


### PR DESCRIPTION
Close #615.

* Added upgrade step for v4.4.
* Added v4.4 to list of version choices.

Already [deployed to dev](https://connect.strategyunitwm.nhs.uk/connect/#/apps/236915c0-9684-4dcc-bd9b-41d21efdd665/content-view) as part of [pre-release](https://github.com/The-Strategy-Unit/nhp_planning/issues/486).