### PR TITLE
Cast sex as character type

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -82,6 +82,7 @@ app_server <- function(input, output, session) {
     # nolint end
     age_sex |>
       dplyr::mutate(
+        dplyr::across("sex", as.character),
         age_group = factor(
           .data[["age_group"]],
           levels = .env[["age_fct"]]


### PR DESCRIPTION
As per https://github.com/The-Strategy-Unit/tpma-explorer/pull/164

The `sex` column in the age-sex data will become an integer with the switch to UDAL. Convert back to character ready for age-sex pyramid plot.