### PR TITLE
Update CODEOWNERS with team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @primary-owner and @secondary-owner will be requested for
-# review when someone opens a pull request.
-*       @matt-dray @StatsRhian
+# the owners will be requested for review when someone opens a pull request.
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository.
+*       @The-Strategy-Unit/nhp_app_devs


### PR DESCRIPTION
* Replaced usernames in `CODEOWNERS` with team `nhp_app_devs`.
* Have explicitly [given admin access](https://github.com/The-Strategy-Unit/nhp_inputs/settings/access) to this repo by that team.