### PR TITLE
Set max year to 2047

### DIFF
--- a/app.R
+++ b/app.R
@@ -5,6 +5,7 @@ app_version_choices <- jsonlite::fromJSON(Sys.getenv(
 
 # CONSTANTS ----
 maximum_model_horizon_year <- 2047
+default_horizon_year <- 2041
 default_baseline_year <- 2023
 
 # HELPERS ----
@@ -326,7 +327,7 @@ ui_body <- function() {
         choices = generate_year_dropdown_choices(
           (default_baseline_year + 1):maximum_model_horizon_year
         ),
-        selected = as.character(maximum_model_horizon_year)
+        selected = as.character(default_horizon_year)
       )
     ),
     bs4Dash::box(
@@ -690,8 +691,7 @@ server <- function(input, output, session) {
   }) |>
     shiny::bindEvent(selected_providers())
 
-  # the end-year range should be 1 year after the start year to max horizon,
-  # which will also be the default if starting from scratch.
+  # the end-year range should be 1 year after the start year to max horizon
   shiny::observe({
     start_yr <- as.numeric(stringr::str_sub(input$start_year, 1, 4))
 
@@ -699,9 +699,9 @@ server <- function(input, output, session) {
       (start_yr + 1):maximum_model_horizon_year
     )
 
-    # Set end year to latest year, otherwise the year stored in existing params
+    # Set end year to default horizon otherwise the year stored in existing params
     selected_end_year <- if (input$scenario_type == "Create new from scratch") {
-      maximum_model_horizon_year
+      default_horizon_year
     } else {
       shiny::req(params())$end_year
     }

--- a/app.R
+++ b/app.R
@@ -4,7 +4,7 @@ app_version_choices <- jsonlite::fromJSON(Sys.getenv(
 ))
 
 # CONSTANTS ----
-maximum_model_horizon_year <- 2041
+maximum_model_horizon_year <- 2047
 default_baseline_year <- 2023
 
 # HELPERS ----
@@ -690,7 +690,7 @@ server <- function(input, output, session) {
   }) |>
     shiny::bindEvent(selected_providers())
 
-  # the end-year range should be 1 year after the start year to the year 2041/42,
+  # the end-year range should be 1 year after the start year to max horizon,
   # which will also be the default if starting from scratch.
   shiny::observe({
     start_yr <- as.numeric(stringr::str_sub(input$start_year, 1, 4))

--- a/home.md
+++ b/home.md
@@ -5,8 +5,7 @@ Changing the provider will update all of the information shown within the inputs
 You will immediately see the map update showing the selected provider, as well as that trusts peers, as defined by the [Trust Peer Finder Tool](https://app.powerbi.com/view?r=eyJrIjoiMjdiOWQ4YTktNmNiNC00MmIwLThjNzktNWVmMmJmMzllNmViIiwidCI6IjUwZjYwNzFmLWJiZmUtNDAxYS04ODAzLTY3Mzc0OGU2MjllMiIsImMiOjh9). The list of these peers is displayed below the map (collapsed by default).
 Clicking on any of the points on the map will reveal the name of the provider.
 
-Once you have chosen a provider, you can pick from one of the baseline years (currently only 2023/24), and then select the year that you want to use as the model horizon.
-This defaults to 2041/42.
+Once you have chosen a provider, you can pick from one of the baseline years and then select the year that you want to use as [the model horizon](https://connect.strategyunitwm.nhs.uk/nhp/project_information/user_guide/FAQ.html#which-year-should-be-selected-as-the-horizon-year).
 
 Finally, you must specify a scenario name - this will be how the results are identified in the inputs app.
 


### PR DESCRIPTION
Close #637.

* Set `maximum_model_horizon_year` variable to `2047`.
* Retained `2041` as default by adding a `default_horizon_year` variable; replaced `maximum_model_horizon_year` where needed.
* Updated support text to remove references to specific years and to link to nhp_project_information.

Checked in the rendered app UI that:

* the dropdown correctly shows years to 2047, but defaults to 2041
* horizon values are written to params