### PR TITLE
changes to model run api

### DIFF
--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -133,17 +133,20 @@ mod_run_model_check_container_status <- function(
             )
             status("Model running [saving results]")
           } else {
-            if (progress$aae > 0 || progress$outpatients >= model_runs) {
+            if (
+              progress[["AaE"]] > 0 || progress[["Outpatients"]] >= model_runs
+            ) {
               stage <- "A&E"
-              complete <- progress$aae
+              complete <- progress[["AaE"]]
             } else if (
-              progress$outpatients > 0 || progress$inpatients >= model_runs
+              progress[["Outpatients"]] > 0 ||
+                progress[["Inpatients"]] >= model_runs
             ) {
               stage <- "Outpatients"
-              complete <- progress$outpatients
+              complete <- progress[["Outpatients"]]
             } else {
               stage <- "Inpatients"
-              complete <- progress$inpatients
+              complete <- progress[["Inpatients"]]
             }
             pcnt <- scales::percent(complete / model_runs, 0.1)
 

--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -52,12 +52,12 @@ mod_run_model_submit <- function(
         if (!stringr::str_detect(version, "^v\\d+-\\d+$")) {
           version <- "dev"
         }
-        results_url(
-          glue::glue(
-            Sys.getenv("NHP_OUTPUTS_URI"),
-            "?{utils::URLencode(results$outputs_app_uri, TRUE)}"
-          )
+
+        url <- glue::glue(
+          "{Sys.getenv('NHP_OUTPUTS_URI')}?{results$dataset}/{results$model_run_id}"
         )
+        cat("results url: ", url, "\n", sep = "")
+        results_url(url)
 
         mod_run_model_check_container_status(
           results[["dataset"]],

--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -43,30 +43,19 @@ mod_run_model_submit <- function(
 
         status("Submitted Model Run")
 
-        version <- results$app_version
-        # generate the results url
-        # nolint start: object_usage_linter
-        f <- encrypt_filename(
-          file.path(
-            "prod",
-            version,
-            results$dataset,
-            glue::glue("{results$scenario}-{results$create_datetime}.json.gz"),
-            fsep = "/"
-          )
-        )
-        # nolint end
-
         # update version for the url
         version <- stringr::str_replace(
-          version,
+          results$app_version,
           "^v(\\d)+\\.(\\d+).*",
           "v\\1-\\2"
         )
+        if (stringr::str_detect(version, "^v\\d+-\\d+$")) {
+          version <- "dev"
+        }
         results_url(
           glue::glue(
             Sys.getenv("NHP_OUTPUTS_URI"),
-            "?{utils::URLencode(f, TRUE)}"
+            "?{utils::URLencode(results$outputs_app_uri, TRUE)}"
           )
         )
 

--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -66,7 +66,11 @@ mod_run_model_submit <- function(
           )
         )
 
-        mod_run_model_check_container_status(results[["id"]], status)
+        mod_run_model_check_container_status(
+          results[["dataset"]],
+          results[["model_run_id"]],
+          status
+        )
       }
     ) |>
     promises::catch(
@@ -78,13 +82,15 @@ mod_run_model_submit <- function(
 }
 
 mod_run_model_check_container_status <- function(
-  id,
+  dataset,
+  model_run_id,
   status,
   error_counter = 10
 ) {
+  id <- glue::glue("{dataset} | {model_run_id}")
   if (error_counter == 0) {
     cat(
-      "error checking status for id: ",
+      "error checking status for model run id: ",
       id,
       ". too many attempts\n",
       sep = ""
@@ -99,7 +105,7 @@ mod_run_model_check_container_status <- function(
       # wait 10 seconds before checking
       Sys.sleep(10)
       req <- httr2::request(Sys.getenv("NHP_API_URI")) |>
-        httr2::req_url_path("api", "model_run_status", id) |>
+        httr2::req_url_path("api", "model_run_status", dataset, model_run_id) |>
         httr2::req_url_query(code = Sys.getenv("NHP_API_KEY"))
 
       httr2::req_perform(req)
@@ -170,14 +176,19 @@ mod_run_model_check_container_status <- function(
         }
 
         # recursive call
-        mod_run_model_check_container_status(id, status, 10)
+        mod_run_model_check_container_status(dataset, model_run_id, status, 10)
       }
     ) |>
     promises::catch(
       \(error) {
         cat("error:", error$message, "\n")
         # recursive call
-        mod_run_model_check_container_status(id, status, error_counter - 1)
+        mod_run_model_check_container_status(
+          dataset,
+          model_run_id,
+          status,
+          error_counter - 1
+        )
       }
     )
 }

--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -2,6 +2,8 @@
 mod_run_model_submit <- function(
   params_json,
   app_version,
+  viewable,
+  full_model_results,
   status,
   results_url
 ) {
@@ -21,7 +23,9 @@ mod_run_model_submit <- function(
     httr2::req_url_path("api", "run_model") |>
     httr2::req_url_query(
       app_version = app_version,
-      code = Sys.getenv("NHP_API_KEY")
+      code = Sys.getenv("NHP_API_KEY"),
+      save_full_model_results = tolower(as.character(full_model_results)),
+      results_viewable = tolower(as.character(viewable))
     ) |>
     httr2::req_body_raw(params_json, "application/json") |>
     httr2::req_method("POST")

--- a/R/mod_run_model_api_calls.R
+++ b/R/mod_run_model_api_calls.R
@@ -49,7 +49,7 @@ mod_run_model_submit <- function(
           "^v(\\d)+\\.(\\d+).*",
           "v\\1-\\2"
         )
-        if (stringr::str_detect(version, "^v\\d+-\\d+$")) {
+        if (!stringr::str_detect(version, "^v\\d+-\\d+$")) {
           version <- "dev"
         }
         results_url(

--- a/R/mod_run_model_server.R
+++ b/R/mod_run_model_server.R
@@ -52,8 +52,20 @@ mod_run_model_server <- function(id, params, schema_text) {
       p <- shiny::req(fixed_params())
       j <- shiny::req(params_json())
 
+      # decide whether the results are viewable to all users: if this is false
+      # then only nhp_devs/nhp_power_users can view the results
+      viewable <- input$results_viewable
+      full_model_results <- input$full_model_results
+
       # submit the model run
-      mod_run_model_submit(j, p$app_version, status, results_url)
+      mod_run_model_submit(
+        j,
+        p$app_version,
+        viewable,
+        full_model_results,
+        status,
+        results_url
+      )
 
       # do not return the promise
       invisible(NULL)

--- a/R/mod_run_model_server.R
+++ b/R/mod_run_model_server.R
@@ -109,6 +109,17 @@ mod_run_model_server <- function(id, params, schema_text) {
       shinyjs::toggleState("download_params", condition = v)
     })
 
+    shiny::observe({
+      show_advanced_options <- any(
+        c("nhp_devs", "nhp_power_users") %in% session$groups
+      )
+      enable_model_run_args <- show_advanced_options || is_local()
+
+      shinyjs::toggle("model_run_args", enable_model_run_args)
+      shinyjs::toggleState("results_viewable", enable_model_run_args)
+      shinyjs::toggleState("full_model_results", enable_model_run_args)
+    })
+
     # download the params when the download button is pressed
     # shiny downloadHandlers do not handle errors well, returning a .html file
     # instead of the intended content. we handle this by disabling the button

--- a/R/mod_run_model_server.R
+++ b/R/mod_run_model_server.R
@@ -130,6 +130,15 @@ mod_run_model_server <- function(id, params, schema_text) {
       shinyjs::toggle("model_run_args", enable_model_run_args)
       shinyjs::toggleState("results_viewable", enable_model_run_args)
       shinyjs::toggleState("full_model_results", enable_model_run_args)
+
+      # by default, if we are in dev or it's a dev/power user, we should set
+      # the results to not be viewable
+      app_is_dev_version <- !stringr::str_starts(params$app_version, "v")
+      shiny::updateCheckboxInput(
+        session,
+        "results_viewable",
+        value = !(show_advanced_options || app_is_dev_version)
+      )
     })
 
     # download the params when the download button is pressed

--- a/R/mod_run_model_ui.R
+++ b/R/mod_run_model_ui.R
@@ -12,6 +12,29 @@ mod_run_model_ui <- function(id) {
   shiny::fluidRow(
     col_4(
       mod_reasons_ui(ns("reasons")),
+      shinyjs::hidden(
+        shiny::div(
+          id = ns("model_run_args"),
+          bs4Dash::box(
+            title = "Model Run Arguments",
+            width = 12,
+            shinyjs::disabled(
+              shiny::checkboxInput(
+                ns("results_viewable"),
+                "Make results viewable to all users",
+                value = TRUE
+              )
+            ),
+            shinyjs::disabled(
+              shiny::checkboxInput(
+                ns("full_model_results"),
+                "Save full model results",
+                value = FALSE
+              )
+            )
+          )
+        )
+      ),
       bs4Dash::box(
         title = "Run Model",
         width = 12,


### PR DESCRIPTION
- **updates call to the status api to use dataset+model_run_id**
- **adds ui elements for whether the model results should be viewable and whether to save full model results. all hidden/disabled as should only be available for advanced users**
- **adds logic to enable new ui elements if user is a power user/developer or running locally**
- **updates api call to use the viewable/full model results options**
- **fixes the results output link**
