### PR TITLE
replaces the azure logic with {azkit}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
     R (>= 4.4.0)
 Imports: 
     arrow,
-    AzureAuth,
+    azkit,
     AzureStor,
     bs4Dash,
     cachem,
@@ -69,7 +69,8 @@ Suggests:
     usethis,
     watchr (>= 0.0.0.9000)
 Remotes:
-    github::tomjemmett/watchr
+    github::tomjemmett/watchr,
+    github::the-strategy-unit/azkit
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB

--- a/R/fct_azure_storage.R
+++ b/R/fct_azure_storage.R
@@ -21,8 +21,8 @@ load_provider_data <- function(
 
 #' Get ADLS Filesystem
 #'
-#' try to use a managed token, this will only work if run in an Azure data centre
-#' if it fails, try instead to use Azure Resource Manager
+#' Get the Azure Data Lake Storage filesystem using the endpoint and container
+#' specified in environment variables. (AZ_STORAGE_EP and AZ_STORAGE_CONTAINER)
 #'
 #' @return the adls filesystem
 get_adls_fs <- function() {

--- a/R/fct_azure_storage.R
+++ b/R/fct_azure_storage.R
@@ -26,18 +26,9 @@ load_provider_data <- function(
 #'
 #' @return the adls filesystem
 get_adls_fs <- function() {
-  ep_uri <- Sys.getenv("LOCAL_STORAGE_EP")
+  token <- azkit::get_auth_token()
 
-  ep <- if (ep_uri != "") {
-    sa_key <- Sys.getenv("LOCAL_STORAGE_KEY")
-
-    AzureStor::adls_endpoint(ep_uri, key = sa_key)
-  } else {
-    ep_uri <- Sys.getenv("AZ_STORAGE_EP")
-    token <- AzureAuth::get_managed_token("https://storage.azure.com/") |>
-      AzureAuth::extract_jwt()
-
-    AzureStor::adls_endpoint(ep_uri, token = token)
-  }
-  AzureStor::adls_filesystem(ep, Sys.getenv("AZ_STORAGE_CONTAINER"))
+  Sys.getenv("AZ_STORAGE_EP") |>
+    AzureStor::adls_endpoint(token = token) |>
+    AzureStor::adls_filesystem(Sys.getenv("AZ_STORAGE_CONTAINER"))
 }

--- a/man/get_adls_fs.Rd
+++ b/man/get_adls_fs.Rd
@@ -10,6 +10,6 @@ get_adls_fs()
 the adls filesystem
 }
 \description{
-try to use a managed token, this will only work if run in an Azure data centre
-if it fails, try instead to use Azure Resource Manager
+Get the Azure Data Lake Storage filesystem using the endpoint and container
+specified in environment variables. (AZ_STORAGE_EP and AZ_STORAGE_CONTAINER)
 }


### PR DESCRIPTION
replaces the existing logic for getting azure auth tokens with `azkit::get_auth_token`.