### PR TITLE
Tell users that 2024/25 is the new baseline

### DIFF
--- a/app.R
+++ b/app.R
@@ -322,9 +322,15 @@ ui_body <- function() {
         )
       ),
       shiny::div(
-        id = "baseline_warning",
+        id = "default_start_warning",
         style = "margin-bottom: 1rem;",
         shiny::icon("circle-info"),
+        "Note that 2024/25 is the default year."
+      ),
+      shiny::div(
+        id = "baseline_warning",
+        style = "margin-bottom: 1rem;",
+        shiny::icon("triangle-exclamation"),
         "You must",
         shiny::a(
           "request your detailed baseline data",


### PR DESCRIPTION
Close #659.

* Added note that 2024/25 is the new baseline default.
* Made the note about requesting baseline data into a warning (i.e. uses warning-triangle symbol).