### PR TITLE
uses the "development" environment during dev deployment

### DIFF
--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -11,6 +11,5 @@ jobs:
     with:
       namespace: "dev"
       inputs_data_version: "dev"
-      environment: "production"
+      environment: "development"
     secrets: inherit
-        

--- a/.github/workflows/connect-publish-manual.yaml
+++ b/.github/workflows/connect-publish-manual.yaml
@@ -15,7 +15,7 @@ on:
         default: "production"
         options:
           - "production"
-          - "new-production"
+          - "development"
   workflow_call:
     inputs:
       namespace:


### PR DESCRIPTION
use separate environments to manage different secrets (e.g. different API endpoints)
