### PR TITLE
Improve year-related env-var handling

### DIFF
--- a/app.R
+++ b/app.R
@@ -1,4 +1,3 @@
-
 # suppress .data warnings
 library(rlang)
 
@@ -10,10 +9,10 @@ app_version_choices <- jsonlite::fromJSON(Sys.getenv(
 ))
 
 years <- list(
-  horizon_max = Sys.getenv("YEAR_HORIZON_MAX"),
-  horizon_default = Sys.getenv("YEAR_HORIZON_DEFAULT"),
-  baseline_default = Sys.getenv("YEAR_BASELINE_DEFAULT"),
-  baseline_min = Sys.getenv("YEAR_BASELINE_MIN")
+  horizon_max = Sys.getenv("YEAR_HORIZON_MAX", "2047"),
+  horizon_default = Sys.getenv("YEAR_HORIZON_DEFAULT", "2041"),
+  baseline_default = Sys.getenv("YEAR_BASELINE_DEFAULT", "2024"),
+  baseline_min = Sys.getenv("YEAR_BASELINE_MIN", "2023")
 ) |>
   purrr::map(as.numeric)
 

--- a/deploy.R
+++ b/deploy.R
@@ -34,7 +34,11 @@ deploy <- function(server, app_id, app_version_choices) {
     appTitle = "NHP: Inputs Selection",
     envVars = c(
       "APP_VERSION_CHOICES",
-      "R_CONFIG_ACTIVE"
+      "R_CONFIG_ACTIVE",
+      "YEAR_HORIZON_DEFAULT",
+      "YEAR_HORIZON_MAX",
+      "YEAR_BASELINE_DEFAULT",
+      "YEAR_BASELINE_MIN"
     )
   )
 }

--- a/deploy.R
+++ b/deploy.R
@@ -31,7 +31,7 @@ deploy <- function(server, app_id, app_version_choices) {
       app_version_choices,
       auto_unbox = TRUE
     ),
-    R_CONFIG_ACTIVE,
+    R_CONFIG_ACTIVE = "production",
     YEAR_HORIZON_MAX = get_env_var("YEAR_HORIZON_MAX"),
     YEAR_HORIZON_DEFAULT = get_env_var("YEAR_HORIZON_DEFAULT"),
     YEAR_BASELINE_DEFAULT = get_env_var("YEAR_BASELINE_DEFAULT"),

--- a/deploy.R
+++ b/deploy.R
@@ -1,3 +1,11 @@
+get_env_var <- function(env_var) {
+  env_val <- Sys.getenv(env_var, unset = NA)
+  if (is.na(env_val)) {
+    stop("Missing required env var: ", env_var)
+  }
+  env_val
+}
+
 deploy <- function(server, app_id, app_version_choices) {
   if (!file.exists("deploy.R") && dir.exists("inputs_selection_app")) {
     withr::local_dir("inputs_selection_app")
@@ -23,7 +31,11 @@ deploy <- function(server, app_id, app_version_choices) {
       app_version_choices,
       auto_unbox = TRUE
     ),
-    R_CONFIG_ACTIVE = "production"
+    R_CONFIG_ACTIVE,
+    YEAR_HORIZON_MAX = get_env_var("YEAR_HORIZON_MAX"),
+    YEAR_HORIZON_DEFAULT = get_env_var("YEAR_HORIZON_DEFAULT"),
+    YEAR_BASELINE_DEFAULT = get_env_var("YEAR_BASELINE_DEFAULT"),
+    YEAR_BASELINE_MIN = get_env_var("YEAR_BASELINE_MIN")
   )
 
   rsconnect::deployApp(


### PR DESCRIPTION
Related to #674, follows #667.

* Set defaults for year-related env vars if not found (including 2047 max year).
* Added year-related env vars to the deploy script.
* Used `get_env_var()` function in deploy to protect from deploying with unset values.

@tomjemmett, you had mentioned (a) setting year defaults and (b) adding env vars to the deploy script; does this match your expectations? Added `get_env_var()` because I don't think we want to hard-code the years into the `withr::local_envvar()` bit. And we might as well protect against unset values in the deployer's local `.Renviron` too.