### PR TITLE
Complete NDG structure with NDG2 in default params

### DIFF
--- a/default_params.json
+++ b/default_params.json
@@ -35,9 +35,24 @@
     "op": {}
   },
   "non-demographic_adjustment": {
-    "ip": {},
-    "op": {},
-    "aae": {}
+    "variant": "variant_2",
+    "value-type": "year-on-year-growth",
+    "values": {
+      "aae": {
+        "ambulance": [1.0121, 1.0142],
+        "walk-in": [1.0121, 1.0142]
+      },
+      "ip": {
+        "elective": [1.0053, 1.0071],
+        "maternity": [1, 1],
+        "non-elective": [0.9955, 1.0017]
+      },
+      "op": {
+        "first": [1.0228, 1.027],
+        "followup": [1.0228, 1.027],
+        "procedure": [1.0228, 1.027]
+      }
+    }
   },
   "activity_avoidance": {
     "ip": {},


### PR DESCRIPTION
Close #675.

* Updated `non-demographic_change` key in default params so it matches the structure required by the json schema.
* Pre-filled the values [with NDG2 values](https://github.com/The-Strategy-Unit/nhp_inputs/blob/2d934087e191f155be4ee18ed80cd9598994a08c/inst/app/data/ndg_variants.json#L22-L41), as this is the default NDG.

After merging and deploying to dev, pre-release QA can begin in the inputs app.