### PR TITLE
Upgrade selection app for v5.1.0

### DIFF
--- a/app.R
+++ b/app.R
@@ -187,6 +187,11 @@ upgrade_params.v4.4 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v5.0 <- function(p) {
+  class(p) <- p$app_version <- "v5.1"
+  upgrade_params(p)
+}
+
 # Insert above a new upgrade step for each new major or minor version
 
 ## LOCATE PARAMS ----

--- a/deploy.R
+++ b/deploy.R
@@ -57,6 +57,7 @@ deploy <- function(server, app_id, app_version_choices) {
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v5.1",
   "v5.0",
   "v4.4",
   "v4.3",


### PR DESCRIPTION
* Add upgrade step for v5.0 to v5.1.
* Add v5.1 to model selection dropdown.

Deploy after merge (dev and prod), change max horizon year env var to 2047 in the deployed app.