### PR TITLE
use oidc with sync action

### DIFF
--- a/.github/workflows/sync-data.yaml
+++ b/.github/workflows/sync-data.yaml
@@ -2,16 +2,16 @@ name: "Sync Data"
 
 # Note on authentication:
 #
-# This action uses OIDC federated credentials for authenticating with GitHub.
+# This action uses OIDC federated credentials for authenticating with Azure.
 #
-# In azure there is a managed identity which has been created and is set to allow federated
+# In Azure there is a managed identity which has been created and is set to allow federated
 # credentials from this repo when the environment is "production".
 #
-# That managed identity has been grated Storage Blob Data Contributor role to the storage account
+# That managed identity has been granted Storage Blob Data Contributor role to the storage account
 # which is being synced with azcopy.
 #
-# So long as those credentials are in place, this action should be able to authenticate with azure
-# and sync data between the specified containers. These permissions do not expire.
+# So long as those credentials are in place, this action should be able to authenticate with Azure
+# and sync data between the specified container. These permissions do not expire.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync-data.yaml
+++ b/.github/workflows/sync-data.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
         default: "vX.Y"
-        
+
   workflow_call:
     inputs:
       from:
@@ -20,14 +20,24 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   sync-data:
     name: "Sync Data"
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
-      # need to generate a SAS token in azure portal for the container
-      # permissions needed: Read/Add/Create/Write/Delete/List
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Download azcopy
         run: |
           curl -s -L https://aka.ms/downloadazcopy-v10-linux | tar zx --strip-components 1
@@ -37,5 +47,5 @@ jobs:
         run: |
           echo "Syncing from ${{ inputs.from }} to ${{ inputs.to }}"
           ./azcopy sync --recursive \
-            "${{ secrets.AZ_STORAGE_EP }}${{ secrets.AZ_STORAGE_CONTAINER }}/${{ inputs.from }}/?${{ secrets.AZ_STORAGE_SAS }}" \
-            "${{ secrets.AZ_STORAGE_EP }}${{ secrets.AZ_STORAGE_CONTAINER }}/${{ inputs.to }}/?${{ secrets.AZ_STORAGE_SAS }}"
+            "${{ secrets.AZ_STORAGE_EP }}${{ secrets.AZ_STORAGE_CONTAINER }}/${{ inputs.from }}" \
+            "${{ secrets.AZ_STORAGE_EP }}${{ secrets.AZ_STORAGE_CONTAINER }}/${{ inputs.to }}"

--- a/.github/workflows/sync-data.yaml
+++ b/.github/workflows/sync-data.yaml
@@ -1,4 +1,17 @@
 name: "Sync Data"
+
+# Note on authentication:
+#
+# This action uses OIDC federated credentials for authenticating with GitHub.
+#
+# In azure there is a managed identity which has been created and is set to allow federated
+# credentials from this repo when the environment is "production".
+#
+# That managed identity has been grated Storage Blob Data Contributor role to the storage account
+# which is being synced with azcopy.
+#
+# So long as those credentials are in place, this action should be able to authenticate with azure
+# and sync data between the specified containers. These permissions do not expire.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync-data.yaml
+++ b/.github/workflows/sync-data.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -44,6 +44,8 @@ jobs:
 
       # NOTE: storage ep should end in a /, so we do not need a slash between ep and container
       - name: Sync Data
+        env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
         run: |
           echo "Syncing from ${{ inputs.from }} to ${{ inputs.to }}"
           ./azcopy sync --recursive \


### PR DESCRIPTION
switches from using sas tokens to OIDC.

this has the benefit that we use a managed identity in azure with specifically scoped access to the data, and through OIDC we get a fresh token as needed.

there were some aditional setup steps, detailed below:

1. create a new managed identity in the same azure resource group as our storage account
2. grant this managed identity storage blob data contributor to the container we use for the inputs app. do not grant it access to any more containers in the account.
3. set up federated credentials in the managed identity. set this to github, to this org/repo, and the production environment
4. in this repos settings, in the production environment, create 3 new secrets: AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID. The client id is found on the managed identity created in step 1.

We have manaually tested that his action works using the workflow dispatch.

