### PR TITLE
Handle time profiles in v5.2 upgrade and default params

### DIFF
--- a/app.R
+++ b/app.R
@@ -192,6 +192,15 @@ upgrade_params.v5.0 <- function(p) {
   upgrade_params(p)
 }
 
+upgrade_params.v5.1() <- function(p) {
+  # Remove time-profile mappings
+
+  p[["time_profile_mappings"]] <- NULL
+
+  class(p) <- p$app_version <- "v5.2"
+  upgrade_params(p)
+}
+
 # Insert above a new upgrade step for each new major or minor version
 
 ## LOCATE PARAMS ----

--- a/app.R
+++ b/app.R
@@ -192,7 +192,7 @@ upgrade_params.v5.0 <- function(p) {
   upgrade_params(p)
 }
 
-upgrade_params.v5.1() <- function(p) {
+upgrade_params.v5.1 <- function(p) {
   # Remove time-profile mappings
 
   p[["time_profile_mappings"]] <- NULL

--- a/default_params.json
+++ b/default_params.json
@@ -63,23 +63,6 @@
     "ip": {},
     "op": {}
   },
-  "time_profile_mappings": {
-    "baseline_adjustment": "none",
-    "activity_avoidance": {
-      "ip": {},
-      "op": {},
-      "aae": {}
-    },
-    "efficiencies": {
-      "ip": {},
-      "op": {}
-    },
-    "expat": "linear",
-    "repat_local": "linear",
-    "repat_nonlocal": "linear",
-    "non-demographic_adjustment": "none",
-    "waiting_list_adjustment": "linear"
-  },
   "reasons": {
     "baseline_adjustment": "",
     "demographic_factors": "",

--- a/deploy.R
+++ b/deploy.R
@@ -57,6 +57,7 @@ deploy <- function(server, app_id, app_version_choices) {
 
 # only use the versions that are deployed to the new server currently
 app_version_choices <- c(
+  "v5.2",
   "v5.1",
   "v5.0",
   "v4.4",


### PR DESCRIPTION
Close #654, close #687.

* Removed time profile mappings key from default params.
* Added removal of time profile element for params upgrading to v5.2.
* Added v5.2 to the list of app versions.

I've tested this locally in conjunction with #655. See the description in that PR for the outcomes.