### PR TITLE
switch to watcher package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,6 @@ Suggests:
     usethis,
     watcher
 Remotes:
-    github::tomjemmett/watchr,
     github::the-strategy-unit/azkit
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rlang,
     scales,
     sf,
-    shiny (>= 1.7.1),
+    shiny (>= 1.14.0),
     shinycssloaders,
     shinyjs,
     shinyWidgets,
@@ -67,7 +67,7 @@ Suggests:
     spelling,
     testthat (>= 3.0.0),
     usethis,
-    watchr (>= 0.0.0.9000)
+    watcher
 Remotes:
     github::tomjemmett/watchr,
     github::the-strategy-unit/azkit

--- a/R/mod_home_ui.R
+++ b/R/mod_home_ui.R
@@ -25,7 +25,7 @@ mod_home_ui <- function(id) {
       collapsible = FALSE,
       width = 12,
       shinycssloaders::withSpinner(
-        gt::gt_output(ns("model_options"))
+        shiny::htmlOutput(ns("model_options"))
       )
     )
   )

--- a/R/mod_mitigators_summary_ui.R
+++ b/R/mod_mitigators_summary_ui.R
@@ -29,7 +29,7 @@ mod_mitigators_summary_ui <- function(id) {
         bs4Dash::box(
           width = 12,
           shinycssloaders::withSpinner(
-            gt::gt_output(ns("diagnoses_table"))
+            shiny::htmlOutput(ns("diagnoses_table"))
           )
         )
       )

--- a/R/mod_mitigators_ui.R
+++ b/R/mod_mitigators_ui.R
@@ -76,7 +76,7 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
               title = "Top 6 Primary Diagnoses",
               if (show_diagnoses_table) {
                 shinycssloaders::withSpinner({
-                  gt::gt_output(ns("diagnoses_table"))
+                  shiny::htmlOutput(ns("diagnoses_table"))
                 })
               } else {
                 shiny::p("No diagnosis data for outpatients.")
@@ -86,7 +86,7 @@ mod_mitigators_ui <- function(id, title, show_diagnoses_table = TRUE) {
             bs4Dash::box(
               title = "Breakdown by Procedure",
               shinycssloaders::withSpinner({
-                gt::gt_output(ns("procedures_table"))
+                shiny::htmlOutput(ns("procedures_table"))
               }),
               width = 12
             )

--- a/R/mod_non_demographic_adjustment_ui.R
+++ b/R/mod_non_demographic_adjustment_ui.R
@@ -48,7 +48,7 @@ mod_non_demographic_adjustment_ui <- function(id) {
         collapsible = FALSE,
         headerBorder = FALSE,
         width = 4,
-        gt::gt_output(ns("non_demographic_adjustment_table"))
+        shiny::htmlOutput(ns("non_demographic_adjustment_table"))
       )
     )
   )

--- a/R/mod_run_model_ui.R
+++ b/R/mod_run_model_ui.R
@@ -60,7 +60,7 @@ mod_run_model_ui <- function(id) {
       width = 8,
       collapsed = TRUE,
       shiny::verbatimTextOutput(ns("params_json")),
-      gt::gt_output(ns("validation_errors"))
+      shiny::htmlOutput(ns("validation_errors"))
     )
   )
 }

--- a/R/mod_waiting_list_imbalances_ui.R
+++ b/R/mod_waiting_list_imbalances_ui.R
@@ -38,7 +38,7 @@ mod_waiting_list_imbalances_ui <- function(id) {
         collapsible = FALSE,
         headerBorder = FALSE,
         width = 8,
-        gt::gt_output(ns("table"))
+        shiny::htmlOutput(ns("table"))
       )
     )
   )

--- a/app.R
+++ b/app.R
@@ -3,7 +3,6 @@
 # Or use the blue button on top of this file
 
 pkgload::load_all(export_all = FALSE, helpers = FALSE, attach_testthat = FALSE)
-options("golem.app.prod" = TRUE)
 
 cat(
   "listing environment variables:\n",

--- a/dev/watch.R
+++ b/dev/watch.R
@@ -1,3 +1,5 @@
+shiny::devmode()
+
 selection_app <- callr::r_bg(\() {
   app <- shiny::runApp(
     "inputs_selection_app",
@@ -8,14 +10,4 @@ selection_app <- callr::r_bg(\() {
 
 cat("Inputs Selection App: http://127.0.0.1:9080\n")
 
-watchr::watch_files_and_start_task(
-  \() {
-    try({
-      pkgload::load_all()
-      print(run_app())
-    })
-  },
-  \() fs::dir_ls(path = c("R"), recurse = TRUE, glob = "*.R"),
-  "inst/golem-config.yml",
-  "DESCRIPTION"
-)
+shiny::runApp()


### PR DESCRIPTION
uses shiny 1.14 and the watcher package, using shiny::devmode in the dev/watch.R script.

devmode turns on some extra checks, which throws warnings due to gt creating and input and output with the same id for every table. switching from gt_output to htmlOutput resolves this (though, it will break interactive gt tables)
