### PR TITLE
fixes warning when converting to json

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,4 +71,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: true
-RoxygenNote: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,16 +4,21 @@ S3method(plot,nhp_funnel_plot)
 export(run_app)
 import(shiny)
 importFrom(golem,with_golem_options)
-importFrom(promises,"%...!%")
-importFrom(promises,"%...>%")
-importFrom(rlang,.data)
-importFrom(rlang,.env)
-importFrom(rlang,`!!!`)
-importFrom(shiny,HTML)
-importFrom(shiny,NS)
-importFrom(shiny,column)
-importFrom(shiny,shinyApp)
-importFrom(shiny,tagAppendAttributes)
-importFrom(shiny,tagList)
-importFrom(shiny,tags)
+importFrom(promises,
+  "%...!%",
+  "%...>%"
+)
+importFrom(rlang,
+  .data,
+  .env
+)
+importFrom(shiny,
+  HTML,
+  NS,
+  column,
+  shinyApp,
+  tagAppendAttributes,
+  tagList,
+  tags
+)
 importFrom(zeallot,"%<-%")

--- a/R/ZZZ.R
+++ b/R/ZZZ.R
@@ -1,5 +1,5 @@
 #' @importFrom zeallot %<-%
-#' @importFrom rlang .data .env `!!!`
+#' @importFrom rlang .data .env
 #' @importFrom promises %...>% %...!%
 NULL
 

--- a/R/mod_expat_repat_server.R
+++ b/R/mod_expat_repat_server.R
@@ -338,7 +338,8 @@ mod_expat_repat_server <- function(id, params) {
           !.data[["is_main_icb"]]
         ) |>
         dplyr::select("icb", "pcnt") |>
-        tibble::deframe()
+        tibble::deframe() |>
+        as.list()
 
       shiny::req(length(icb_pcnts) > 0)
 


### PR DESCRIPTION
sending custom message with a named vector causes a warning from jsonlite that this is going to be deprecated in the future. convert the vector to a list and the warning goes away
